### PR TITLE
fix: set environment in create_release_pr

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,7 @@ jobs:
   create_release_pr:
     name: create_release_pr
     runs-on: ubuntu-latest
+    environment: create-prs
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret is now only provided through the `create-prs` environment. So this environment needs to be set from the `create_release_pr` job.